### PR TITLE
fix bug # readLength

### DIFF
--- a/lib/composer.js
+++ b/lib/composer.js
@@ -112,7 +112,7 @@ pro._readLength = function(data, offset, end) {
 		length *= LEFT_SHIFT_BITS;		// left shift only within 32 bits
 		length += (b & 0x7f);
 
-		if(length > this.maxLength) {
+		if(this.maxLength > 0 && length > this.maxLength) {
 			this.state = ST_ERROR;
 			this.emit('length_limit', this, data, offset);
 			return -1;


### PR DESCRIPTION
fix bugs: when maxLength is 0 or -1, ignore it and do not compare with length
